### PR TITLE
fix: 修复两个在 Python 3.12 以下版本存在的 f 字符串问题

### DIFF
--- a/catfood/functions/github/api.py
+++ b/catfood/functions/github/api.py
@@ -44,8 +44,9 @@ catfood.functions.github.api 的 "获取GitHub文件内容" 函数的 github_tok
         if (len(repo.split("/")) < 2) or (len(repo.split("/")) > 3):
             raise ValueError("指定的仓库格式不对")
         
+        normalized_path = path.replace("\\", "/")
         response = 请求GitHubAPI(
-            f"https://api.github.com/repos/{repo}/contents/{path.replace("\\", "/")}",
+            f"https://api.github.com/repos/{repo}/contents/{normalized_path}",
             token=token
         )
 

--- a/catfood/functions/terminal.py
+++ b/catfood/functions/terminal.py
@@ -40,7 +40,7 @@ def runCommand(command: list[str] | str, retry: int = -1) -> int:
                 if result.returncode == 0:
                     return 0
                 else:
-                    print(f"{消息头.错误} 运行 {Fore.BLUE}{" ".join(command)}{Fore.RESET} 失败，{command[0]} 返回非零退出代码 {Fore.BLUE}{result.returncode}{Fore.RESET}")
+                    print(f"{消息头.错误} 运行 {Fore.BLUE}{' '.join(command)}{Fore.RESET} 失败，{command[0]} 返回非零退出代码 {Fore.BLUE}{result.returncode}{Fore.RESET}")
 
                     if retry < 0:
                         return result.returncode
@@ -69,7 +69,7 @@ def runCommand(command: list[str] | str, retry: int = -1) -> int:
 
             print(f"{消息头.信息} 正在重试 ...")
     except KeyboardInterrupt:
-        print(f"{消息头.错误} 终止运行命令 {Fore.BLUE}{" ".join(command)}{Fore.RESET}，因为收到了 Ctrl + C (KeyboardInterrupt)")
+        print(f"{消息头.错误} 终止运行命令 {Fore.BLUE}{' '.join(command)}{Fore.RESET}，因为收到了 Ctrl + C (KeyboardInterrupt)")
         raise KeyboardInterrupt
 
 def calculateCharactersDisplayed(content: str) -> int:


### PR DESCRIPTION
- Python 3.12 之前 f 字符串的表达式部分中不允许使用转义序列(反斜杠)
- 嵌套在 f 字符串中的字符串不能使用与 Python 3.12 之前的 f 字符串相同的引号字符