### PR TITLE
fix(func/terminal): 修复当 `result.stderr` 或 `result.stdout` 为 `None` 时调用 `str.strip()` 会出现 `AttributeError` 的问题

### DIFF
--- a/catfood/functions/terminal.py
+++ b/catfood/functions/terminal.py
@@ -31,9 +31,10 @@ def runCommand(command: list[str] | str, retry: int = -1) -> int:
     while True:
         try:
             result = subprocess.run(command, capture_output=True, text=True, check=False)
-            if result.stdout.strip():
+            # 这两个输出可能为 None，见 #42 / #43
+            if result.stdout:
                 print(result.stdout.strip())
-            if result.stderr.strip():
+            if result.stderr:
                 print(result.stderr.strip())
 
             if result.returncode == 0:

--- a/tests/functions/test_terminal.py
+++ b/tests/functions/test_terminal.py
@@ -53,6 +53,31 @@ def test_runCommand_failure_no_retry(monkeypatch: pytest.MonkeyPatch, capsys: py
 @pytest.mark.parametrize(
     "arg",
     [
+        ["fcm", "get"],
+        "fcm get"
+    ]
+)
+def test_runCommand_failure_no_out(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], arg: list[str] | str):
+    """
+    https://github.com/DuckDuckStudio/catfood/issues/43
+    """
+
+    def dummy_run(cmd: list[str], capture_output: Literal[True], text: Literal[True], check: Literal[False]):
+        class Result:
+            returncode = 1
+            stdout = None
+            stderr = None
+        return Result()
+    monkeypatch.setattr(terminal.subprocess, "run", dummy_run)
+    ret = terminal.runCommand(arg, retry=-1)
+    out = capsys.readouterr().out
+    assert ret == 1
+    assert 消息头.错误 in out
+    assert "fcm" in out
+
+@pytest.mark.parametrize(
+    "arg",
+    [
         ["git", "status"],
         "git status"
     ]


### PR DESCRIPTION
- Fixes #43 并添加相关单元测试