### PR TITLE
types(func/format/github): 为 ResolvesIssue 函数的 string 参数的类型注释添加 int | None

### DIFF
--- a/catfood/functions/format/github.py
+++ b/catfood/functions/format/github.py
@@ -6,7 +6,7 @@ def IssueNumber(string: str | int | None) -> str | None:
     """
     从给定的字符串中获取 Issue 或 PR 的编号。
     
-    :param string: 给定的字符串或整数或 None
+    :param string: 给定的输入内容
     :type string: str | int | None
     :return: 返回字符串的编号，获取失败返回 None
     :rtype: str | None
@@ -36,14 +36,14 @@ def IssueNumber(string: str | int | None) -> str | None:
 
     return None
 
-def ResolvesIssue(string: str, keyword: str = "Resolves") -> str | None:
+def ResolvesIssue(string: str | int | None, keyword: str = "Resolves") -> str | None:
     """
     将给定的字符串格式化为 GitHub PR 的 Resolves Issue 格式
 
     GitHub Docs: https://docs.github.com/zh/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
     
-    :param string: 给定的字符串
-    :type string: str
+    :param string: 给定的输入内容
+    :type string: str | int | None
     :param keyword: 链接议题时使用的关键词
     :type keyword: str
     :return: 格式化成功返回字符串结果，失败返回 None


### PR DESCRIPTION
- Resolves #15 

该函数内部通过 `IssueNumber(...) -> str | None` 函数实现，这个函数早就已经接受了 `int | None` 输入。

这里只有对类型注释和文档字符串的修改，没有修改实现逻辑。
你在没有添加类型注释前直接传 `int | None` 应该也是没问题的，只是一些类型检查会抱怨。

我自己早就为这两种参数类型写了单元测试，但我怎么拖了两个月才加上... 我真的是太懒了...

![我已经写的测试，main 分支](https://github.com/user-attachments/assets/cb93335b-2764-4d3d-99e2-9fd70dff0102)
