### PR TITLE
refactor!(func/format/github): 将该模块下的两个函数的 `string` 参数的名称修改为 `content`

### DIFF
--- a/catfood/functions/format/github.py
+++ b/catfood/functions/format/github.py
@@ -2,32 +2,32 @@
 将传入的字符统一为某种 GitHub 上的格式。
 """
 
-def IssueNumber(string: str | int | None) -> str | None:
+def IssueNumber(content: str | int | None) -> str | None:
     """
     从给定的字符串中获取 Issue 或 PR 的编号。
     
-    :param string: 给定的输入内容
-    :type string: str | int | None
+    :param content: 给定的输入内容
+    :type content: str | int | None
     :return: 返回字符串的编号，获取失败返回 None
     :rtype: str | None
     """
 
-    if not string:
+    if not content:
         return None
-    elif isinstance(string, int) and (string > 0):
-        return str(string)
-    elif isinstance(string, str):
-        string = string.strip().lstrip("#").lstrip("0")
-        if (not string):
+    elif isinstance(content, int) and (content > 0):
+        return str(content)
+    elif isinstance(content, str):
+        content = content.strip().lstrip("#").lstrip("0")
+        if (not content):
             return None
-        elif string.isdigit():
+        elif content.isdigit():
             # 这里理应是已经去除前导零的正整数
             # 因为 000 啥的会直接被 lstrip 掉
-            return string
-        elif string.startswith("https://"):
+            return content
+        elif content.startswith("https://"):
             try:
                 from urllib.parse import urlparse
-                for seg in reversed(urlparse(string).path.split('/')):
+                for seg in reversed(urlparse(content).path.split('/')):
                     if seg.isdigit():
                         if (segNum := int(seg)) > 0:
                             return str(segNum)
@@ -36,21 +36,21 @@ def IssueNumber(string: str | int | None) -> str | None:
 
     return None
 
-def ResolvesIssue(string: str | int | None, keyword: str = "Resolves") -> str | None:
+def ResolvesIssue(content: str | int | None, keyword: str = "Resolves") -> str | None:
     """
     将给定的字符串格式化为 GitHub PR 的 Resolves Issue 格式
 
     GitHub Docs: https://docs.github.com/zh/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
     
-    :param string: 给定的输入内容
-    :type string: str | int | None
+    :param content: 给定的输入内容
+    :type content: str | int | None
     :param keyword: 链接议题时使用的关键词
     :type keyword: str
     :return: 格式化成功返回字符串结果，失败返回 None
     :rtype: str | None
     """
 
-    num: str | None = IssueNumber(string)
+    num: str | None = IssueNumber(content)
 
     if num:
         return f"- {keyword} #{num}"


### PR DESCRIPTION
- Resolves https://github.com/DuckDuckStudio/catfood/issues/48
- Relate https://github.com/DuckDuckStudio/catfood/pull/47#issuecomment-4471410614

原先的 `string` 只限定于字符串，但实际它还能接受 `int | None`。