### PR TITLE
tests(func/format/github): 添加 IssueNumber 函数输入链接包含非 int() 能转换的数字时的测试

### DIFF
--- a/tests/functions/format/test_github.py
+++ b/tests/functions/format/test_github.py
@@ -15,6 +15,7 @@ from catfood.functions.format.github import IssueNumber, ResolvesIssue
         ("#notanumber", None),
         ("abc", None),
         ("https://github.com/owner/repo/issues/", None),
+        ("https://github.com/owner/repo/issues/₁", None),
         # 有效输入
         (123, "123"),
         ("123", "123"),

--- a/tests/functions/format/test_github.py
+++ b/tests/functions/format/test_github.py
@@ -6,10 +6,16 @@ from catfood.functions.format.github import IssueNumber, ResolvesIssue
 @pytest.mark.parametrize(
     "input_value,expected",
     [
+        # 无效输入
         (None, None),
         ("", None),
         (0, None),
         (-1, None),
+        ("#000", None),
+        ("#notanumber", None),
+        ("abc", None),
+        ("https://github.com/owner/repo/issues/", None),
+        # 有效输入
         (123, "123"),
         ("123", "123"),
         ("#123", "123"),
@@ -19,11 +25,6 @@ from catfood.functions.format.github import IssueNumber, ResolvesIssue
         ("https://github.com/owner/repo/issues/456", "456"),
         ("https://github.com/owner/repo/pull/789", "789"),
         ("https://github.com/owner/repo/issues/000789", "789"),
-        ("https://github.com/owner/repo/issues/notanumber", None),
-        ("#notanumber", None),
-        ("abc", None),
-        ("#000", None),
-        ("https://github.com/owner/repo/issues/", None),
         ("https://github.com/owner/repo/issues/123#discussion", "123"),
         ("https://github.com/owner/repo/issues/123#issuecomment-456", "123"),
     ]


### PR DESCRIPTION
- **tests(func/format/github): 分类 test_IssueNumber 测试用例**
- **tests(func/format/github): 添加 IssueNumber 函数输入链接包含非 int() 能转换的数字的测试**
