### PR TITLE
chore(deps): 移除不再需要的依赖项 keyring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "colorama>=0.4.6",
-    "requests>=2.32.5",
-    "keyring>=25.6.0",
+    "requests>=2.32.5"
 ]
 
 [project.urls]


### PR DESCRIPTION
keyring 在 catfood 2.0.0 以前被 catfood.functions.github.token 依赖。
在 catfood 2.0.0 以后，该模块被移除 (#27)，catfood 不再依赖 keyring。