### PR TITLE
ci(isort): 仅要求 Python 3.x

### DIFF
--- a/.github/workflows/isort.yaml
+++ b/.github/workflows/isort.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: 配置 Python
         uses: actions/setup-python@v6.1.0
         with:
-          python-version: 3.14.x
+          python-version: 3.x
 
       - name: 安装依赖
         run: pip install isort


### PR DESCRIPTION
而不是 3.14.x